### PR TITLE
Allow user to add arguments to command

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   ],
   "engines": {
     "vscode": "^1.71.0",
-    "pnpm": "9.9.0",
-    "node": "22.7.0",
+    "pnpm": ">=9.9.0",
+    "node": "^22.7.0",
     "npm": "please-use-pnpm"
   },
   "activationEvents": [
@@ -49,6 +49,13 @@
               "command": {
                 "markdownDescription": "Command ID of the VS Code command to run.",
                 "type": "string"
+              },
+              "args": {
+                "markdownDescription": "Command arguments, listed as array of strings.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               },
               "statusBarText": {
                 "markdownDescription": "The text to display in the status bar. Use the `$(<name>)` syntax to display icons from the [VS Code icon set](https://code.visualstudio.com/api/references/icons-in-labels#icon-listing).",
@@ -95,14 +102,15 @@
     "package": "pnpm check-types && node esbuild.js --production",
     "vscode:prepublish": "pnpm package",
     "vsce-publish": "vsce publish",
+    "vsce-package": "vsce package -o dist/vscode-statusbar-commands.vsix",
     "prettier": "prettier . --write --cache --cache-strategy metadata"
   },
   "devDependencies": {
-    "@types/node": "22.5.2",
-    "@types/vscode": "1.71.0",
-    "@vscode/vsce": "3.0.0",
-    "esbuild": "0.23.1",
-    "prettier": "3.3.3",
-    "typescript": "5.5.4"
+    "@types/node": "^22.5.2",
+    "@types/vscode": "^1.71.0",
+    "@vscode/vsce": "^3.0.0",
+    "esbuild": "^0.23.1",
+    "prettier": "^3.3.3",
+    "typescript": "^5.5.4"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import vscode from 'vscode';
 
-type Command = { statusBarText: string; command: string; tooltipText: string; color: string };
+type Command = { statusBarText: string; command: string; args: string[]; tooltipText: string; color: string };
 type Alignment = 'Left' | 'Right';
 
 export const activate = (context: vscode.ExtensionContext) => {
@@ -31,7 +31,7 @@ export const activate = (context: vscode.ExtensionContext) => {
 
   const registerCommand = (cmd: Command, index: number) => {
     return vscode.commands.registerCommand(`statusbar-commands.runUserCommand${index}`, async () => {
-      await vscode.commands.executeCommand(cmd.command);
+      await vscode.commands.executeCommand(cmd.command, ...(cmd.args ?? []));
     });
   };
 


### PR DESCRIPTION
It would be convenient if user can supply arguments to the command. 
After a quick research I found that this is possible as the signature of `vscode.commands.executeCommand` is : 
`executeCommand<T>(command: string, ...rest: any[]): Thenable<T>`
where `rest` is arguments passed to the command function.
I've also updated the `package.json` so that the dependency version reflects the latest toolchain versions. While doing so, I also add command `vsce-package` to generate VSIX package to `dist` directory.

Sincerely yours.