### PR TITLE
Add support for passing arguments to status bar commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Changelog
 
+## [2.1.0] - 2025-06-23
+
+### Added
+
+- **Command Arguments**: Support for an optional `args` array for each command.
+
 ## [2.0.3] - 2024-09-19
 
 ### Improved

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This extension contributes the following settings:
   - `command`: The ID of the VSCode command to run when the status bar item is clicked.
   - `tooltipText`: (Optional) The text to display as a tooltip when hovering over the status bar item.
   - `color`: (Optional) The color of the status bar item text (e.g., `#ff0000`, `red`). Accepts any valid CSS color value.
+  - `args` (Optional) An array of arguments to pass to the command when it is executed.
 
 - `statusbarCommands.alignment`: Controls the alignment of the status bar commands (either `Left` or `Right`). Default is `Right`.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-statusbar-commands",
   "displayName": "VSCode Statusbar Commands",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "This VSCode extension allows you to customize your VSCode status bar by adding quick-access commands with user-defined icons and tooltips. Easily configure and manage commands to streamline your workflow, all directly from your status bar.",
   "main": "./dist/extension.js",
   "author": {
@@ -61,6 +61,11 @@
               "color": {
                 "markdownDescription": "The color of the status bar text (e.g., `#ff0000`, `red`). Accepts any valid CSS color value.",
                 "type": "string"
+              },
+              "args": {
+                "type": "array",
+                "markdownDescription": "Arguments to pass to the command",
+                "items": {}
               }
             },
             "required": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import vscode from 'vscode';
 
-type Command = { statusBarText: string; command: string; tooltipText: string; color: string };
+type Command = { args?: any[], statusBarText: string; command: string; tooltipText?: string; color?: string };
 type Alignment = 'Left' | 'Right';
 
 export const activate = (context: vscode.ExtensionContext) => {
@@ -30,9 +30,19 @@ export const activate = (context: vscode.ExtensionContext) => {
   };
 
   const registerCommand = (cmd: Command, index: number) => {
-    return vscode.commands.registerCommand(`statusbar-commands.runUserCommand${index}`, async () => {
-      await vscode.commands.executeCommand(cmd.command);
-    });
+    return vscode.commands.registerCommand(
+      `statusbar-commands.runUserCommand${index}`,
+      async () => {
+        if (cmd.args && cmd.args.length > 0) {
+          await vscode.commands.executeCommand(
+            cmd.command,
+            ...cmd.args
+          );
+        } else {
+          await vscode.commands.executeCommand(cmd.command);
+        }
+      }
+    );
   };
 
   const initializeStatusBarCommands = () => {


### PR DESCRIPTION
# Add support for passing arguments to status bar commands
This PR introduces an optional `args` field on each `statusbarCommands.commands` entry, allowing invocation of VS Code commands with custom parameters directly from the status bar.

## What’s Changed
- Extended the `Command` type to include `args?: any[]`.
- Updated `registerCommand()` to spread `cmd.args` into `vscode.commands.executeCommand(...)` when present.

## Credit
This feature was proposed by @devilxnux in PR #1. Thanks @devilxnux for the suggestion!